### PR TITLE
Compare using 32bit registers for non long long types

### DIFF
--- a/gen.c
+++ b/gen.c
@@ -351,7 +351,10 @@ static void emit_comp(char *inst, Node *node) {
         push("rax");
         emit_expr(node->right);
         pop("rcx");
-        emit("cmp %%rax, %%rcx");
+        if (node->left->ctype->type == CTYPE_LLONG)
+          emit("cmp %%rax, %%rcx");
+        else
+          emit("cmp %%eax, %%ecx");
     }
     emit("%s %%al", inst);
     emit("movzb %%al, %%eax");


### PR DESCRIPTION
How to reproduce:

Compile this by gcc

int f() {
  return -1;
}

and this by 8cc

int main(void) {
  printf("%d\n",f()<1);
}
