### PR TITLE
Fix the range of non-universal character names.

### DIFF
--- a/lex.c
+++ b/lex.c
@@ -338,7 +338,7 @@ static int read_hex_char(void) {
 }
 
 static bool is_valid_ucn(unsigned int c) {
-    if (0x800 <= c && c <= 0xDFFF)
+    if (0xD800 <= c && c <= 0xDFFF)
         return false;
     return 0xA0 <= c || c == '$' || c == '@' || c == '`';
 }


### PR DESCRIPTION
If I correctly understand the paragraph 2 of `6.4.3 Universal character names` of N1570, A character `c` is not a universal character name if c in [`0xD800`, `0xDFFF]`
