### PR TITLE
Fixed issue with pointer arith.

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -534,7 +534,22 @@ static Type *usual_arith_conv(Type *t, Type *u) {
     return r;
 }
 
+static bool valid_pointer_binop(int op) {
+    switch (op) {
+    case '-': case '<': case '>': case OP_EQ:
+    case OP_NE: case OP_GE: case OP_LE:
+        return true;
+    default:
+        return false;
+    }
+}
+
 static Node *binop(int op, Node *lhs, Node *rhs) {
+    if (lhs->ty->kind == KIND_PTR && rhs->ty->kind == KIND_PTR) {
+        if (!valid_pointer_binop(op))
+            error("invalid pointer arith");
+        return ast_binop(type_int, op, lhs, rhs);
+    }
     if (lhs->ty->kind == KIND_PTR)
         return ast_binop(lhs->ty, op, lhs, rhs);
     if (rhs->ty->kind == KIND_PTR)

--- a/test/pointer.c
+++ b/test/pointer.c
@@ -47,6 +47,13 @@ static void t6(void) {
     expect(1, p->next->val);
 }
 
+static void t7() {
+    int a;
+    int *p1 = &a + 1;
+    int *p2 = 1 + &a;
+    expect(0, p1 - p2);
+}
+
 static void subtract(void) {
     char *p = "abcdefg";
     char *q = p + 5;
@@ -61,5 +68,6 @@ void testmain(void) {
     t4();
     t5();
     t6();
+    t7();
     subtract();
 }


### PR DESCRIPTION
As mentioned in the other PR I closed, This uses a blacklist because the whitelist would need to include < > <= >= && || which take up even more space. Hopefully I didn't miss any operators.

I also learnt how to squash commits which is handy :).
