### PR TITLE
Pointer comparators and difference match the C standard.

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -548,6 +548,10 @@ static Node *binop(int op, Node *lhs, Node *rhs) {
     if (lhs->ty->kind == KIND_PTR && rhs->ty->kind == KIND_PTR) {
         if (!valid_pointer_binop(op))
             error("invalid pointer arith");
+        // C11 6.5.6.9: Pointer subtractions have type ptrdiff_t.
+        if (op == '-')
+            return ast_binop(type_long, op, lhs, rhs);
+        // C11 6.5.8.6, 6.5.9.3: Pointer comparisons have type int.
         return ast_binop(type_int, op, lhs, rhs);
     }
     if (lhs->ty->kind == KIND_PTR)

--- a/test/pointer.c
+++ b/test/pointer.c
@@ -57,7 +57,32 @@ static void t7() {
 static void subtract(void) {
     char *p = "abcdefg";
     char *q = p + 5;
+    expect(8, sizeof(q - p));
     expect(5, q - p);
+}
+
+static void compare(void) {
+    char *p = "abcdefg";
+    expect(0, p == p + 1);
+    expect(1, p == p);
+    expect(0, p != p);
+    expect(1, p != p + 1);
+    expect(0, p < p);
+    expect(1, p < p + 1);
+    expect(0, p > p);
+    expect(1, p + 1 > p);
+    expect(1, p >= p);
+    expect(1, p + 1 >= p);
+    expect(0, p >= p + 1);
+    expect(1, p <= p);
+    expect(1, p <= p + 1);
+    expect(0, p + 1 <= p);
+    expect(4, sizeof(p == p + 1));
+    expect(4, sizeof(p != p + 1));
+    expect(4, sizeof(p < p + 1));
+    expect(4, sizeof(p > p + 1));
+    expect(4, sizeof(p <= p + 1));
+    expect(4, sizeof(p >= p + 1));
 }
 
 void testmain(void) {
@@ -70,4 +95,5 @@ void testmain(void) {
     t6();
     t7();
     subtract();
+    compare();
 }


### PR DESCRIPTION
Fixed two issues with pointer operations.
C11 6.5.6.9: Ptr subtraction have type ptrdiff_t.
C11 6.5.8.6, 6.5.9.3: Ptr comparisons have type int.
