### PR TITLE
Fix a null dereference.

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -803,6 +803,8 @@ static Vector *read_func_args(Vector *params) {
     for (;;) {
         if (next_token(')')) break;
         Node *arg = conv(read_assignment_expr());
+        if (!arg)
+            error("previous argument is invalid");
         Type *paramtype;
         if (i < vec_len(params)) {
             paramtype = vec_get(params, i++);


### PR DESCRIPTION
Fixed a null pointer deference if a call argument is a keyword.

example:

```
extern int foo(int);
int main() {  return foo(int); }
```
