### PR TITLE
Fix segfault with long long globals.

### DIFF
--- a/gen.c
+++ b/gen.c
@@ -1305,6 +1305,8 @@ static void emit_data_primtype(Type *ty, Node *val, int depth) {
         break;
     case KIND_LONG:
     case KIND_LLONG:
+        emit(".quad %u", eval_intexpr(val));
+        break;
     case KIND_PTR: {
         bool is_char_ptr = (val->operand->ty->kind == KIND_ARRAY && val->operand->ty->ptr->kind == KIND_CHAR);
         if (is_char_ptr) {

--- a/test/global.c
+++ b/test/global.c
@@ -17,6 +17,8 @@ char *s2 = "ABCD";
 long l1 = 8;
 int *intp = &(int){ 9 };
 
+long long z = 5LL;
+
 void testmain(void) {
     print("global variable");
 
@@ -45,4 +47,6 @@ void testmain(void) {
 
     expectl(8, l1);
     expectl(9, *intp);
+
+    expectll(5, z);
 }

--- a/test/test.h
+++ b/test/test.h
@@ -16,6 +16,7 @@ extern void fexpect_string(char *file, int line, char *a, char *b);
 extern void fexpectf(char *file, int line, float a, float b);
 extern void fexpectd(char *file, int line, double a, double b);
 extern void fexpectl(char *file, int line, long a, long b);
+extern void fexpectll(char *file, int line, long long a, long long b);
 
 #define fail(msg) ffail(__FILE__, __LINE__, msg)
 #define expect(a, b) fexpect(__FILE__, __LINE__, a, b);
@@ -23,3 +24,4 @@ extern void fexpectl(char *file, int line, long a, long b);
 #define expectf(a, b) fexpectf(__FILE__, __LINE__, a, b);
 #define expectd(a, b) fexpectd(__FILE__, __LINE__, a, b);
 #define expectl(a, b) fexpectl(__FILE__, __LINE__, a, b);
+#define expectll(a, b) fexpectll(__FILE__, __LINE__, a, b);

--- a/test/testmain.c
+++ b/test/testmain.c
@@ -77,6 +77,14 @@ void fexpectl(char *file, int line, long a, long b) {
     }
 }
 
+void fexpectll(char *file, int line, long long a, long long b) {
+    if (!(a == b)) {
+        printfail();
+        printf("%s:%d: %lld expected, but got %lld\n", file, line, a, b);
+        exit(1);
+    }
+}
+
 int main() {
     testmain();
     printf(isatty(fileno(stdout)) ? "\e[32mOK\e[0m\n" : "OK\n");


### PR DESCRIPTION
A global of the form "long long z = 5LL;" would trigger a null
pointer dereference.
