### PR TITLE
Fix static void pointers which point to label addresses.

### DIFF
--- a/gen.c
+++ b/gen.c
@@ -1287,10 +1287,9 @@ static void emit_data_primtype(Type *ty, Node *val, int depth) {
         emit(".long %d", *(uint32_t *)&f);
         break;
     }
-    case KIND_DOUBLE: {
+    case KIND_DOUBLE:
         emit(".quad %ld", *(uint64_t *)&val->fval);
         break;
-    }
     case KIND_BOOL:
         emit(".byte %d", !!eval_intexpr(val));
         break;
@@ -1305,7 +1304,11 @@ static void emit_data_primtype(Type *ty, Node *val, int depth) {
         break;
     case KIND_LONG:
     case KIND_LLONG:
-    case KIND_PTR: {
+    case KIND_PTR:
+        if (val->kind == OP_LABEL_ADDR) {
+            emit(".quad %s", val->newlabel);
+            break;
+        }
         bool is_char_ptr = (val->operand->ty->kind == KIND_ARRAY && val->operand->ty->ptr->kind == KIND_CHAR);
         if (is_char_ptr) {
             emit_data_charptr(val->operand->sval, depth);
@@ -1315,7 +1318,6 @@ static void emit_data_primtype(Type *ty, Node *val, int depth) {
             emit(".quad %u", eval_intexpr(val));
 	}
         break;
-    }
     default:
         error("don't know how to handle\n  <%s>\n  <%s>", c2s(ty), a2s(val));
     }

--- a/test/control.c
+++ b/test/control.c
@@ -258,6 +258,10 @@ static void test_computed_goto(void) {
     goto *t.y;
  a:
     ;
+    static void *p = &&L;
+    goto *p;
+ L:
+    ;
 }
 
 static void test_logor(void) {


### PR DESCRIPTION
Segfaults occured if a static pointer was assigned to
an &&label value, this was because the OP_LABEL_ADDR case
hadn't been handled in gen.c. A test case was added.

Also fixed some whitespace issues.
