### PR TITLE
Add usual conv to unary minus.

### DIFF
--- a/gen.c
+++ b/gen.c
@@ -702,6 +702,7 @@ static void emit_literal(Node *node) {
     switch (node->ty->kind) {
     case KIND_BOOL:
     case KIND_CHAR:
+    case KIND_SHORT:
         emit("mov $%u, #rax", node->ival);
         break;
     case KIND_INT:

--- a/parse.c
+++ b/parse.c
@@ -1074,7 +1074,7 @@ static Node *read_unary_minus(void) {
     Node *expr = read_cast_expr();
     ensure_arithtype(expr);
     if (is_inttype(expr->ty))
-        return binop('-', ast_inttype(expr->ty, 0), expr);
+        return binop('-', conv(ast_inttype(expr->ty, 0)), conv(expr));
     return binop('-', ast_floattype(expr->ty, 0), expr);
 }
 

--- a/test/arith.c
+++ b/test/arith.c
@@ -75,6 +75,15 @@ static void test_ternary(void) {
     expect(3, (1 + 2) ?: 52);
 }
 
+static void test_unary(void) {
+    char x = 2;
+    short y = 2;
+    int z = 2;
+    expect(-2, -x);
+    expect(-2, -y);
+    expect(-2, -z);
+}
+
 static void test_comma(void) {
     expect(3, (1, 3));
     expectf(7.0, (1, 3, 5, 7.0));
@@ -86,6 +95,7 @@ void testmain(void) {
     test_relative();
     test_inc_dec();
     test_bool();
+    test_unary();
     test_ternary();
     test_comma();
 }


### PR DESCRIPTION
This change fixes an assertion error when performing unary minus on
char or short.
