### PR TITLE
Respect ty->usig in get_load_inst.

### DIFF
--- a/gen.c
+++ b/gen.c
@@ -124,10 +124,10 @@ static char *get_int_reg(Type *ty, char r) {
 
 static char *get_load_inst(Type *ty) {
     switch (ty->size) {
-    case 1: return "movsbq";
-    case 2: return "movswq";
-    case 4: return "movslq";
-    case 8: return "mov";
+    case 1: return ty->usig ? "movzbq" : "movsbq";
+    case 2: return ty->usig ? "movzwq" : "movswq";
+    case 4: return ty->usig ? "mov" : "movslq";
+    case 8: return "movq";
     default:
         error("Unknown data size: %s: %d", ty2s(ty), ty->size);
     }

--- a/gen.c
+++ b/gen.c
@@ -122,11 +122,20 @@ static char *get_int_reg(Type *ty, char r) {
     }
 }
 
-static char *get_load_inst(Type *ty) {
+static char *get_load_inst(Type *ty, char **dest) {
+    *dest = "rax";
+
     switch (ty->size) {
     case 1: return ty->usig ? "movzbq" : "movsbq";
     case 2: return ty->usig ? "movzwq" : "movswq";
-    case 4: return ty->usig ? "mov" : "movslq";
+    case 4: {
+        if (ty->usig) {
+            *dest = "eax";
+            return "mov";
+        }
+
+        return "movslq";
+    }
     case 8: return "movq";
     default:
         error("Unknown data size: %s: %d", ty2s(ty), ty->size);
@@ -229,8 +238,9 @@ static void emit_gload(Type *ty, char *label, int off) {
             emit("lea %s(#rip), #rax", label);
         return;
     }
-    char *inst = get_load_inst(ty);
-    emit("%s %s+%d(#rip), #rax", inst, label, off);
+    char *dest;
+    char *inst = get_load_inst(ty, &dest);
+    emit("%s %s+%d(#rip), #%s", inst, label, off, dest);
     maybe_emit_bitshift_load(ty);
 }
 
@@ -269,8 +279,9 @@ static void emit_lload(Type *ty, char *base, int off) {
     } else if (ty->kind == KIND_DOUBLE || ty->kind == KIND_LDOUBLE) {
         emit("movsd %d(#%s), #xmm0", off, base);
     } else {
-        char *inst = get_load_inst(ty);
-        emit("%s %d(#%s), #rax", inst, off, base);
+        char *dest;
+        char *inst = get_load_inst(ty, &dest);
+        emit("%s %d(#%s), #%s", inst, off, base, dest);
         maybe_emit_bitshift_load(ty);
     }
 }

--- a/gen.c
+++ b/gen.c
@@ -234,6 +234,24 @@ static void emit_gload(Type *ty, char *label, int off) {
     maybe_emit_bitshift_load(ty);
 }
 
+static void emit_intcast(Type *ty) {
+    switch(ty->kind) {
+    case KIND_BOOL:
+    case KIND_CHAR:
+        ty->usig ? emit("movzbq #al, #rax") : emit("movsbq #al, #rax");
+        return;
+    case KIND_SHORT:
+        ty->usig ? emit("movzwq #ax, #rax") : emit("movswq #ax, #rax");
+        return;
+    case KIND_INT:
+        ty->usig ? emit("mov #eax, #eax") : emit("cltq");
+        return;
+    case KIND_LONG:
+    case KIND_LLONG:
+        return;
+    }
+}
+
 static void emit_toint(Type *ty) {
     SAVE;
     if (ty->kind == KIND_FLOAT)
@@ -512,6 +530,8 @@ static void emit_load_convert(Type *to, Type *from) {
         emit("cvtpd2ps #xmm0, #xmm0");
     else if (to->kind == KIND_BOOL)
         emit_to_bool(from);
+    else if (is_inttype(from) && is_inttype(to))
+        emit_intcast(from);
     else if (is_inttype(to))
         emit_toint(from);
 }

--- a/test/intcast.c
+++ b/test/intcast.c
@@ -1,0 +1,26 @@
+// Copyright 2012 Rui Ueyama <rui314@gmail.com>
+// This program is free software licensed under the MIT license.
+
+#include "test.h"
+
+static void test_signedcast(void) {
+    unsigned char c = -1;
+    int i = (signed char) c;
+
+    expect(i, -1);
+}
+
+static void test_unsignedcast(void) {
+    signed char c = -1;
+    int i = (unsigned char) c;
+
+    expect(1, i > 0);
+}
+
+void testmain(void) {
+    print("integer casts");
+
+    test_signedcast();
+    test_unsignedcast();
+}
+


### PR DESCRIPTION
get_load_inst needs to consider the signed-ness of the type
that it's emitting a load instruction for. If the load is
unsigned, emit zero-extended load instructions.