### PR TITLE
Add optional support for Boehm garbage collector.

### DIFF
--- a/8cc.h
+++ b/8cc.h
@@ -10,6 +10,14 @@
 #include <stdio.h>
 #include <stdnoreturn.h>
 
+// Boehm garbage collector
+#ifdef USEGC
+    #include <gc.h>
+    #define malloc GC_MALLOC
+    #define realloc GC_REALLOC
+    #define calloc(m,n) GC_MALLOC((m)*(n))
+#endif
+
 enum {
     TIDENT,
     TKEYWORD,

--- a/HACKING.md
+++ b/HACKING.md
@@ -20,8 +20,14 @@ Compiler is not a long-running process.
 It will never run out of memory unless you give an
 unrealistically large source file.
 
-If we really need to free memory, we could use Boehm garbage
-collector. I don't see that need at this moment though.
+8cc supports the use of the Boehm garbage collector,
+though it is disabled by default.
+
+If you wish to use the Boehm garbage collector:
+
+- install it on ubuntu ```apt-get install libgc-dev```
+- install it on arch linux ```pacman -S gc```
+- build 8cc with ```make USEGC=true```
 
 # Backend
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 CFLAGS=-Wall -Wno-strict-aliasing -std=gnu11 -g -I. -O0
+ifeq ($(USEGC), true)
+    CFLAGS+=-DUSEGC=1
+    LDFLAGS+=-lgc
+endif
 OBJS=cpp.o debug.o dict.o gen.o lex.o vector.o parse.o buffer.o map.o \
      error.o path.o file.o set.o encoding.o
 TESTS := $(patsubst %.c,%.bin,$(filter-out test/testmain.c,$(wildcard test/*.c)))

--- a/main.c
+++ b/main.c
@@ -166,6 +166,9 @@ static void preprocess() {
 }
 
 int main(int argc, char **argv) {
+    #ifdef USEGC
+        GC_INIT();
+    #endif
     setbuf(stdout, NULL);
     if (atexit(delete_temp_files))
         perror("atexit");


### PR DESCRIPTION
This is disabled by default.
Adds support for  ```make USEGC=true```