### PR TITLE
Specify python version in test/negative.py

### DIFF
--- a/test/negative.py
+++ b/test/negative.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Copyright 2015 Rui Ueyama. Released under the MIT license.
 
 # This file contains negative tests.


### PR DESCRIPTION
As many linux distrobutions use python3 as the default
python interperter, this script may encounter an error.