### PR TITLE
Fix a parser bug in struct initialization.

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -1635,8 +1635,9 @@ static void skip_to_brace() {
 }
 
 static void read_initializer_elem(Vector *inits, Type *ty, int off, bool designated) {
+    bool ident = (peek()-> kind == TIDENT);
     next_token('=');
-    if (ty->kind == KIND_ARRAY || ty->kind == KIND_STRUCT) {
+    if (!ident && (ty->kind == KIND_ARRAY || ty->kind == KIND_STRUCT)) {
         read_initializer_list(inits, ty, off, designated);
     } else if (next_token('{')) {
         read_initializer_elem(inits, ty, off, true);

--- a/test/initializer.c
+++ b/test/initializer.c
@@ -47,6 +47,11 @@ static void test_struct() {
     int we[] = { 1, 0, 0, 0, 2, 0, 0, 0 };
     struct { int a[3]; int b; } w[] = { { 1 }, 2 };
     verify(we, &w, 8);
+
+    struct foo { int a; int b; } f = { 1, 2 };
+    struct { struct foo f; } b = { f };
+    expect(b.f.a, 1);
+    expect(b.f.b, 2);
 }
 
 static void test_primitive() {


### PR DESCRIPTION
When initializing a struct containing a struct via a variable (see
test/initializer.c, function test_struct()):

    struct foo { int a; int b; } f = { 1, 2 };
    struct { struct foo f; } b = { f };

8cc failed with a type error:
[ERROR] parse.c:617: (null): incompatible kind: <int> <(struct (int) (int))>

The read_initializer_elem function did not expect an identifier as a valid
struct member initializer. This patch seems to fix that (make fulltest
passes with the above-mentioned test added).