### PR TITLE
8cc codegen is accessing (potentially) uninitialized struct fields

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -9,8 +9,8 @@
 #define INIT_SIZE 8
 
 Buffer *make_buffer() {
-    Buffer *r = malloc(sizeof(Buffer));
-    r->body = malloc(INIT_SIZE);
+    Buffer *r = calloc(1, sizeof(Buffer));
+    r->body = calloc(1, INIT_SIZE);
     r->nalloc = INIT_SIZE;
     r->len = 0;
     return r;
@@ -18,7 +18,7 @@ Buffer *make_buffer() {
 
 static void realloc_body(Buffer *b) {
     int newsize = b->nalloc * 2;
-    char *body = malloc(newsize);
+    char *body = calloc(1, newsize);
     memcpy(body, b->body, b->len);
     b->body = body;
     b->nalloc = newsize;

--- a/cpp.c
+++ b/cpp.c
@@ -55,14 +55,14 @@ static Token *read_expand(void);
  */
 
 static CondIncl *make_cond_incl(bool wastrue) {
-    CondIncl *r = malloc(sizeof(CondIncl));
+    CondIncl *r = calloc(1, sizeof(CondIncl));
     r->ctx = IN_THEN;
     r->wastrue = wastrue;
     return r;
 }
 
 static Macro *make_macro(Macro *tmpl) {
-    Macro *r = malloc(sizeof(Macro));
+    Macro *r = calloc(1, sizeof(Macro));
     *r = *tmpl;
     return r;
 }
@@ -81,7 +81,7 @@ static Macro *make_special_macro(SpecialMacroHandler *fn) {
 }
 
 static Token *make_macro_token(int position, bool is_vararg) {
-    Token *r = malloc(sizeof(Token));
+    Token *r = calloc(1, sizeof(Token));
     r->kind = TMACRO_PARAM;
     r->is_vararg = is_vararg;
     r->hideset = NULL;
@@ -92,7 +92,7 @@ static Token *make_macro_token(int position, bool is_vararg) {
 }
 
 static Token *copy_token(Token *tok) {
-    Token *r = malloc(sizeof(Token));
+    Token *r = calloc(1, sizeof(Token));
     *r = *tok;
     return r;
 }

--- a/dict.c
+++ b/dict.c
@@ -4,7 +4,7 @@
 #include "8cc.h"
 
 Dict *make_dict() {
-    Dict *r = malloc(sizeof(Dict));
+    Dict *r = calloc(1, sizeof(Dict));
     r->map = make_map();
     r->key = make_vector();
     return r;

--- a/gen.c
+++ b/gen.c
@@ -645,7 +645,7 @@ static void emit_fill_holes(Vector *inits, int off, int totalsize) {
     // If at least one of the fields in a variable are initialized,
     // unspecified fields has to be initialized with 0.
     int len = vec_len(inits);
-    Node **buf = malloc(len * sizeof(Node *));
+    Node **buf = calloc(len, sizeof(Node *));
     for (int i = 0; i < len; i++)
         buf[i] = vec_get(inits, i);
     qsort(buf, len, sizeof(Node *), cmpinit);
@@ -784,7 +784,7 @@ static char **split(char *buf) {
         p++;
     }
     p = buf;
-    char **r = malloc(sizeof(char *) * len + 1);
+    char **r = calloc(len + 1, sizeof(char *));
     int i = 0;
     while (*p) {
         if (p[0] == '\r' && p[1] == '\n') {
@@ -809,7 +809,7 @@ static char **read_source_file(char *file) {
         return NULL;
     struct stat st;
     fstat(fileno(fp), &st);
-    char *buf = malloc(st.st_size + 1);
+    char *buf = calloc(1, st.st_size + 1);
     if (fread(buf, 1, st.st_size, fp) != st.st_size)
         return NULL;
     fclose(fp);

--- a/lex.c
+++ b/lex.c
@@ -71,7 +71,7 @@ static void mark() {
 }
 
 static Token *make_token(Token *tmpl) {
-    Token *r = malloc(sizeof(Token));
+    Token *r = calloc(1, sizeof(Token));
     *r = *tmpl;
     r->hideset = NULL;
     File *f = current_file();

--- a/map.c
+++ b/map.c
@@ -20,7 +20,7 @@ static uint32_t hash(char *p) {
 }
 
 static Map *do_make_map(Map *parent, int size) {
-    Map *r = malloc(sizeof(Map));
+    Map *r = calloc(1, sizeof(Map));
     r->parent = parent;
     r->key = calloc(size, sizeof(char *));
     r->val = calloc(size, sizeof(void *));

--- a/parse.c
+++ b/parse.c
@@ -327,19 +327,19 @@ static Node *ast_label_addr(char *label) {
 }
 
 static Type *make_type(Type *tmpl) {
-    Type *r = malloc(sizeof(Type));
+    Type *r = calloc(1, sizeof(Type));
     *r = *tmpl;
     return r;
 }
 
 static Type *copy_type(Type *ty) {
-    Type *r = malloc(sizeof(Type));
+    Type *r = calloc(1, sizeof(Type));
     memcpy(r, ty, sizeof(Type));
     return r;
 }
 
 static Type *make_numtype(int kind, bool usig) {
-    Type *r = malloc(sizeof(Type));
+    Type *r = calloc(1, sizeof(Type));
     r->kind = kind;
     r->usig = usig;
     if (kind == KIND_VOID)         r->size = r->align = 0;

--- a/parse.c
+++ b/parse.c
@@ -115,7 +115,7 @@ enum {
 
 static void mark_location() {
     Token *tok = peek();
-    source_loc = malloc(sizeof(SourceLoc));
+    source_loc = calloc(1, sizeof(SourceLoc));
     source_loc->file = tok->file->name;
     source_loc->line = tok->line;
 }
@@ -141,7 +141,7 @@ static char *make_static_label(char *name) {
 }
 
 static Case *make_case(int beg, int end, char *label) {
-    Case *r = malloc(sizeof(Case));
+    Case *r = calloc(1, sizeof(Case));
     r->beg = beg;
     r->end = end;
     r->label = label;
@@ -153,7 +153,7 @@ static Map *env() {
 }
 
 static Node *make_ast(Node *tmpl) {
-    Node *r = malloc(sizeof(Node));
+    Node *r = calloc(1, sizeof(Node));
     *r = *tmpl;
     r->sourceLoc = source_loc;
     return r;
@@ -487,7 +487,7 @@ static bool next_token(int kind) {
 }
 
 void *make_pair(void *first, void *second) {
-    void **r = malloc(sizeof(void *) * 2);
+    void **r = calloc(2, sizeof(void *));
     r[0] = first;
     r[1] = second;
     return r;

--- a/set.c
+++ b/set.c
@@ -18,7 +18,7 @@
 #include "8cc.h"
 
 Set *set_add(Set *s, char *v) {
-    Set *r = malloc(sizeof(Set));
+    Set *r = calloc(1, sizeof(Set));
     r->next = s;
     r->v = v;
     return r;

--- a/vector.c
+++ b/vector.c
@@ -24,10 +24,10 @@ static int roundup(int n) {
 }
 
 static Vector *do_make_vector(int size) {
-    Vector *r = malloc(sizeof(Vector));
+    Vector *r = calloc(1, sizeof(Vector));
     size = roundup(size);
     if (size > 0)
-        r->body = malloc(sizeof(void *) * size);
+        r->body = calloc(size, sizeof(void *));
     r->len = 0;
     r->nalloc = size;
     return r;
@@ -41,7 +41,7 @@ static void extend(Vector *vec, int delta) {
     if (vec->len + delta <= vec->nalloc)
         return;
     int nelem = max(roundup(vec->len + delta), MIN_SIZE);
-    void *newbody = malloc(sizeof(void *) * nelem);
+    void *newbody = calloc(nelem, sizeof(void *));
     memcpy(newbody, vec->body, sizeof(void *) * vec->len);
     vec->body = newbody;
     vec->nalloc = nelem;


### PR DESCRIPTION
When using a `malloc()` implementation that doesn't clear the memory region (which is permitted behaviour according to the standards) it is quite easy for 8cc to generate invalid assembly code.  I first noticed this issue when compiling 8cc under OpenBSD, which has a `malloc()` implementation that does *not* always clear memory before allocating it to the user program.

The symptom was `maybe_emit_bitshift_load()` and `maybe_emit_bitshift_save()` generating bogus SHR and SHL instructions when the `bitsize` field (signed int32) is less than or equal to zero, which happens frequently when referencing memory which hasn't been cleared.  Thankfully GNU `as` caught the issue and aborted without generating an object file.

To be safe, I've changed all `malloc(size)` calls to use `calloc(nmemb, size)` instead.