### PR TITLE
Fix nested parens in declarators.

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -1960,6 +1960,7 @@ static Type *read_declarator(char **rname, Type *basety, Vector *params, int ctx
         // Here, we pass a dummy object to get "pointer to <something>" first,
         // continue reading to get "function returning int", and then combine them.
         Type *stub = make_stub_type();
+        *stub = *basety;
         Type *t = read_declarator(rname, stub, params, ctx);
         expect(')');
         *stub = *read_declarator_tail(basety, params);

--- a/test/decl.c
+++ b/test/decl.c
@@ -4,7 +4,8 @@
 
 static void t1() {
     int a = 1;
-    expect(3, a + 2);
+    int ((b)) = 2;
+    expect(5, a + b + 2);
 }
 
 static void t2() {


### PR DESCRIPTION
The stub type does not pass the basetype to the nested declarator in the case that there are nested parens and no tail, this patch fixes that.