### PR TITLE
Fix NetBSD build: Include missing header for va_list in 8cc.h

### DIFF
--- a/8cc.h
+++ b/8cc.h
@@ -5,6 +5,7 @@
 
 #include <assert.h>
 #include <inttypes.h>
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdnoreturn.h>


### PR DESCRIPTION
This addresses:

```
cc -Wall -Wno-strict-aliasing -std=gnu11 -g -I. -O0 -DBUILD_DIR='"/public/8cc"'   -c -o main.o main.c
In file included from main.c:9:0:
8cc.h:311:26: error: unknown type name ‘va_list’
 char *vformat(char *fmt, va_list ap);
                          ^
<builtin>: recipe for target 'main.o' failed
gmake: *** [main.o] Error 1
```