### PR TITLE
Try user include paths before standard ones

### DIFF
--- a/cpp.c
+++ b/cpp.c
@@ -704,7 +704,7 @@ static void read_include(Token *hash, File *file, bool isimport) {
         if (try_include(dir, filename, isimport))
             return;
     }
-    for (int i = vec_len(std_include_path) - 1; i >= 0; i--)
+    for (int i = 0; i < vec_len(std_include_path); i++)
         if (try_include(vec_get(std_include_path, i), filename, isimport))
             return;
   err:
@@ -725,13 +725,13 @@ static void read_include_next(Token *hash, File *file) {
         goto err;
     }
     char *cur = fullpath(file->name);
-    int i = vec_len(std_include_path) - 1;
-    for (; i >= 0; i--) {
+    int i = 0;
+    for (; i < vec_len(std_include_path); i++) {
         char *dir = vec_get(std_include_path, i);
         if (!strcmp(cur, fullpath(format("%s/%s", dir, filename))))
             break;
     }
-    for (i--; i >= 0; i--)
+    for (i++; i < vec_len(std_include_path); i++)
         if (try_include(vec_get(std_include_path, i), filename, false))
             return;
   err:
@@ -935,12 +935,12 @@ static void init_keywords() {
 }
 
 static void init_predefined_macros() {
-    vec_push(std_include_path, "/usr/include/x86_64-linux-gnu");
-    vec_push(std_include_path, "/usr/include/linux");
-    vec_push(std_include_path, "/usr/include");
-    vec_push(std_include_path, "/usr/local/include");
-    vec_push(std_include_path, "/usr/local/lib/8cc/include");
     vec_push(std_include_path, BUILD_DIR "/include");
+    vec_push(std_include_path, "/usr/local/lib/8cc/include");
+    vec_push(std_include_path, "/usr/local/include");
+    vec_push(std_include_path, "/usr/include");
+    vec_push(std_include_path, "/usr/include/linux");
+    vec_push(std_include_path, "/usr/include/x86_64-linux-gnu");
 
     define_special_macro("__DATE__", handle_date_macro);
     define_special_macro("__TIME__", handle_time_macro);


### PR DESCRIPTION
User defined include paths are pushed to the vector before
system include paths as we handle command line flags before
calling cpp_init. Iterating this vector in reverse order
prefers system headers to user headers, which is wrong.

A test case:

$ echo 'int main() {}' > stdio.h
$ echo '#include <stdio.h>' > test.c
$ ./8cc -I. -c test.c && gcc test.o
/usr/lib/gcc/x86_64-linux-gnu/5/../../../x86_64-linux-gnu/crt1.o: In function `_start':
(.text+0x20): undefined reference to `main'
collect2: error: ld returned 1 exit status

This partially reverts bcaf3b2648e but this was broken even
before the removal of vec_unshift, I think.