### PR TITLE
Fix values of function designators

### DIFF
--- a/gen.c
+++ b/gen.c
@@ -1208,7 +1208,7 @@ static void emit_expr(Node *node) {
     case AST_LITERAL: emit_literal(node); return;
     case AST_LVAR:    emit_lvar(node); return;
     case AST_GVAR:    emit_gvar(node); return;
-    case AST_FUNCDESG: return;
+    case AST_FUNCDESG: emit_addr(node); return;
     case AST_FUNCALL:
         if (maybe_emit_builtin(node))
             return;

--- a/test/function.c
+++ b/test/function.c
@@ -163,6 +163,16 @@ static void test_funcdesg() {
     test_funcdesg;
 }
 
+typedef int (*t6_t)(void);
+
+static t6_t retfunc() {
+  return &t6;
+}
+
+static t6_t retfunc2() {
+  return t6;
+}
+
 // _Alignas is a declaration specifier containing parentheses.
 // Make sure the compiler doesn't interpret it as a function definition.
 static _Alignas(32) char char32;
@@ -190,4 +200,6 @@ void testmain() {
     test_bool();
     test_struct();
     test_funcdesg();
+    expect(3, retfunc()());
+    expect(3, retfunc2()());
 }


### PR DESCRIPTION
Before this patch, functions without an unary & didn't have
any values.

I'm not 100% sure if this is a right thing to do, but it seems
to fix a few cases at least.