### PR TITLE
Correct dependencies of test binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,12 @@ $(OBJS) utiltest.o main.o: 8cc.h keyword.inc
 utiltest: 8cc.h utiltest.o $(OBJS)
 	cc -o $@ utiltest.o $(OBJS) $(LDFLAGS)
 
-test/%.o: test/%.c
+ifeq ($(CC),$(ECC))
+TEST_DEP := $(CC)
+else
+TEST_DEP :=
+endif
+test/%.o: test/%.c $(TEST_DEP)
 	$(CC) $(CFLAGS) -w -o $@ -c $<
 
 test/%.bin: test/%.o test/testmain.o

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,8 @@ $(OBJS) utiltest.o main.o: 8cc.h keyword.inc
 utiltest: 8cc.h utiltest.o $(OBJS)
 	cc -o $@ utiltest.o $(OBJS) $(LDFLAGS)
 
-ifeq ($(CC),$(ECC))
-TEST_DEP := $(CC)
-else
-TEST_DEP :=
-endif
-test/%.o: test/%.c $(TEST_DEP)
-	$(CC) $(CFLAGS) -w -o $@ -c $<
+test/%.o: test/%.c $(ECC)
+	$(ECC) -w -o $@ -c $<
 
 test/%.bin: test/%.o test/testmain.o
 	cc -o $@ $< test/testmain.o $(LDFLAGS)
@@ -27,8 +22,8 @@ test/%.bin: test/%.o test/testmain.o
 self: 8cc cleanobj
 	$(MAKE) CC=$(ECC) CFLAGS= 8cc
 
-test: 8cc
-	$(MAKE) CC=$(ECC) CFLAGS= utiltest $(TESTS)
+test: 8cc $(TESTS)
+	$(MAKE) CC=$(ECC) CFLAGS= utiltest
 	./utiltest
 	./test/ast.sh
 	./test/negative.py


### PR DESCRIPTION
The first commit is what I want. It tries to keep the current behavior
(you can build test/*.o by host CC). However, I think the behavior
change done by the second commit is a good one.
