### PR TITLE
The movement of inc/decrement must follow its type

### DIFF
--- a/gen.c
+++ b/gen.c
@@ -677,7 +677,7 @@ static void emit_decl_init(Vector *inits, int off, int totalsize) {
 
 static void emit_pre_inc_dec(Node *node, char *op) {
     emit_expr(node->operand);
-    emit("%s $1, #rax", op);
+    emit("%s $%d, #rax", op, node->ty->ptr ? node->ty->ptr->size : 1);
     emit_store(node->operand);
 }
 
@@ -685,7 +685,7 @@ static void emit_post_inc_dec(Node *node, char *op) {
     SAVE;
     emit_expr(node->operand);
     push("rax");
-    emit("%s $1, #rax", op);
+    emit("%s $%d, #rax", op, node->ty->ptr ? node->ty->ptr->size : 1);
     emit_store(node->operand);
     pop("rax");
 }

--- a/test/struct.c
+++ b/test/struct.c
@@ -310,6 +310,26 @@ static void empty_struct() {
     expect(0, sizeof(union tag16));
 }
 
+static void incdec_struct() {
+    struct incdec {
+	int x, y;
+    } a[] = { { 1, 2 }, { 3, 4 } }, *p = a;
+    expect(1, p->x);
+    expect(2, p->y);
+    p++;
+    expect(3, p->x);
+    expect(4, p->y);
+    p--;
+    expect(1, p->x);
+    expect(2, p->y);
+    ++p;
+    expect(3, p->x);
+    expect(4, p->y);
+    --p;
+    expect(1, p->x);
+    expect(2, p->y);
+}
+
 void testmain() {
     print("struct");
     t1();


### PR DESCRIPTION
~~~~
#include <stdio.h>

struct pair {
    int x;
    int y;
} a[] = { { 1, 2 }, { 3, 4 } }, *p = a;

int main() {
    p++;
    printf("%d\n", p->x);
}
~~~~

3 is expected, but actually it prints 33554432.