### PR TITLE
Fix 16 dependency issues in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ $(OBJS) utiltest.o main.o: 8cc.h keyword.inc
 
 utiltest: 8cc.h utiltest.o $(OBJS)
 	cc -o $@ utiltest.o $(OBJS) $(LDFLAGS)
+	
+$(filter %.o,$(OBJS)): %.o: %.c
+utiltest.o: utiltest.c
+main.o: main.c
 
 test/%.o: test/%.c $(ECC)
 	$(ECC) -w -o $@ -c $<


### PR DESCRIPTION
Hi, I've fixed 16 missing dependencies reported.
Those issues can cause incorrect results when 8cc is incrementally built.
For example, any changes in "main.c" will not cause "main.o" to be rebuilt, which is incorrect. The dependency rule in line 16 of the fixed Makefile can solve the dependence issues of 14 targets, including "vector.o", buffer.o", "path.o" and etc.
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

Thanks
Vemake