### PR TITLE
Fix 16 missing dependencies and 1 excessive dependency in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,12 @@ override CFLAGS += -DBUILD_DIR='"$(shell pwd)"'
 
 $(OBJS) utiltest.o main.o: 8cc.h keyword.inc
 
-utiltest: 8cc.h utiltest.o $(OBJS)
+utiltest: utiltest.o $(OBJS)
 	cc -o $@ utiltest.o $(OBJS) $(LDFLAGS)
+
+$(filter %.o,$(OBJS)): %.o: %.c
+utiltest.o: utiltest.c
+main.o: main.c
 
 test/%.o: test/%.c $(ECC)
 	$(ECC) -w -o $@ -c $<


### PR DESCRIPTION
Hi, I've fixed 16 missing dependencies and 1 excessive dependency reported.
Those issues can cause incorrect results or unnecessary rebuilds when 8cc is incrementally built.
For example, any changes in "main.c" will not cause "main.o" to be rebuilt, which is incorrect. The dependency rule in line 16 of the fixed Makefile can solve the dependence issues of 14 targets, including "vector.o", buffer.o", "path.o" and etc.
"8cc.h" is not read by the process when the target “utiltest" is built. Hence, the change of this file can cause an unnecessary rebuild of "utiltest", which slow down the build of the whole project.
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

Thanks
Vemake